### PR TITLE
Implement spinner stop method

### DIFF
--- a/src/spinner/spinner.js
+++ b/src/spinner/spinner.js
@@ -143,11 +143,15 @@ export default class Spinner extends Component {
   loop() {
     if (this._continuous) {
       this._progressPath.style.strokeOpacity = 1;
-      window.requestAnimationFrame(timestamp => this._animateLoop(timestamp));
+      this._animationFrameId = window.requestAnimationFrame(timestamp => this._animateLoop(timestamp));
     }
   }
 
-  stop() {}
+  stop() {
+    if (this._animationFrameId) {
+      window.cancelAnimationFrame(this._animationFrameId);
+    }
+  }
 
   resize() {
     const size = this._element.offsetWidth;
@@ -191,7 +195,7 @@ export default class Spinner extends Component {
     // this._group.setAttributeNS(null, 'transform', `rotate(${this._rotate})`);
     this._groupProgress.setAttributeNS(null, 'transform', `rotate(${this._rotate})`);
 
-    window.requestAnimationFrame(timestamp => this._animateLoop(timestamp));
+    this._animationFrameId = window.requestAnimationFrame(timestamp => this._animateLoop(timestamp));
   }
 
   _updateClasses() {


### PR DESCRIPTION
Implement stop method to prevent recursive animation frame requests, which are unnecessary when the spinner is not visible, and can block protractor tests.